### PR TITLE
Added new file utils and made img mgr loading more dynamic

### DIFF
--- a/src/bluecadet/utils/FileUtils.cpp
+++ b/src/bluecadet/utils/FileUtils.cpp
@@ -1,0 +1,59 @@
+#include "FileUtils.h"
+
+#include "cinder/Filesystem.h"
+#include "cinder/Log.h"
+
+#include <algorithm>
+#include <string>
+
+using namespace ci;
+using namespace std;
+
+namespace bluecadet {
+namespace utils {
+
+void FileUtils::find(const ci::fs::path & dir, FileCallback callback, const std::set<std::string> extensions, const bool recursive, const bool lowercaseExtensions) {
+	if (!fs::exists(dir)) {
+		CI_LOG_E("Directory at '" + dir.string() + "' doesn't exist.");
+		return;
+	}
+
+	int numVideosLoaded = 0;
+
+	for (fs::directory_iterator it(dir); it != fs::directory_iterator(); ++it) {
+		const fs::path filePath = it->path();
+
+		if (is_directory(filePath)) {
+			find(filePath, callback, extensions, recursive);
+			continue;
+		}
+
+		if (!fs::exists(filePath)) {
+			CI_LOG_E("Could not access file at '" + filePath.string() + "'.");
+			continue;
+		}
+
+		string extension = getExtension(filePath);
+
+		if (lowercaseExtensions) {
+			transform(extension.begin(), extension.end(), extension.begin(), tolower);
+		}
+
+		if (!extensions.empty() && extensions.find(extension) == extensions.end()) {
+			continue;
+		}
+
+		callback(filePath);
+	}
+}
+
+std::string FileUtils::getFilename(const ci::fs::path & path) {
+	return path.filename().string(); // You can ignore any IntelliSense errors here. This should build.
+}
+
+std::string FileUtils::getExtension(const ci::fs::path & path) {
+	return path.extension().string(); // You can ignore any IntelliSense errors here. This should build.
+}
+
+}
+}

--- a/src/bluecadet/utils/FileUtils.h
+++ b/src/bluecadet/utils/FileUtils.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <functional>
+#include <set>
+
+#include "cinder/Filesystem.h"
+
+namespace bluecadet {
+namespace utils {
+
+class FileUtils {
+
+public:
+	
+	typedef std::function<void(const ci::fs::path & path)> FileCallback;
+
+	/// <summary>
+	/// Finds all files in a directory and triggers callback on each depth-first.
+	/// </summary>
+	/// <param name="dir">The absolute dir path.</param>
+	/// <param name="callback">Callback that will be triggered for each file.</param>
+	/// <param name="extensions">Valid extensions to load, e.g. {".json", ".csv"}. If lowercaseExtensions is true, all extensions should be lowercase only.</param>
+	/// <param name="recursive">Will load all subdirectories too if set to true.</param>
+	/// <param name="lowercaseExtensions">If true, will convert all found extensions to lowercase. This presumes that all extenssions in the extensions parameter are also lowercase.</param>
+	static void find(const ci::fs::path & dir, FileCallback callback, const std::set<std::string> extensions = {}, const bool recursive = true, const bool lowercaseExtensions = true);
+
+	//! Filename including extension. Avoids issues with compiler/IDE version discrepancies.
+	static std::string getFilename(const ci::fs::path & path);
+
+	//! Extension starting at the last '.' (e.g. 'file.ext' will return '.ext'). Avoids issues with compiler/IDE version discrepancies.
+	static std::string getExtension(const ci::fs::path & path);
+};
+
+}
+}

--- a/src/bluecadet/utils/ImageManager.h
+++ b/src/bluecadet/utils/ImageManager.h
@@ -27,27 +27,43 @@ public:
 		return instance;
 	}
 
-public:
 	~ImageManager();
 
-	void					loadAllImagesInDirectory(const std::string &directory);
-	void					loadAllImagesInDirectory(const std::string &directory, const ci::gl::Texture::Format format);
-	bool					hasTexture(const std::string &filename);
-	ci::gl::Texture2dRef	getTexture(const std::string &filename);
+	/// <summary>
+	/// Loads a single image at absFilePath and uses its filename as key.
+	/// </summary>
+	void load(const ci::fs::path & absFilePath, const ci::gl::Texture::Format & format = getDefaultFormat());
 
-	ci::gl::Texture::Format	getDefaultFormat() const { return mDefaultFormat; }
-	void					setDefaultFormat(const ci::gl::Texture::Format value) { mDefaultFormat = value; }
+	/// <summary>
+	/// Loads a single image at absFilePath and stores it under key.
+	/// </summary>
+	void load(const ci::fs::path & absFilePath, const std::string & key, const ci::gl::Texture::Format & format = getDefaultFormat());
+
+	/// <summary>
+	/// Loads all from dir.
+	/// </summary>
+	/// <param name="absDirPath">The absolute dir path.</param>
+	/// <param name="extensions">Valid extensions to load, e.g. {".jpg", ".png"}.</param>
+	/// <param name="recursive">Will load all subdirectories too if set to true.</param>
+	/// <param name="fileNameAsKey">When true, will use the filename (e.g. "image.jpg"). When false, will use the full path as key (e.g. "C:\Users\Dev\Documents\image.jpg").</param>
+	/// <param name="format">The texture format used for textures.</param>
+	void loadAllFromDir(const ci::fs::path absDirPath, const std::set<std::string> extensions = {".jpg", ".jpeg", ".png"}, const bool recursive = true, const bool fileNameAsKey = true, const ci::gl::Texture::Format & format = getDefaultFormat());
+
+	bool hasTexture(const std::string & key) const;
+	ci::gl::Texture2dRef getTexture(const std::string & key) const;
+
+	static const ci::gl::Texture::Format & getDefaultFormat();
+	static void setDefaultFormat(ci::gl::Texture::Format value);
 
 private:
 
 	ImageManager();
-	std::string		extractFilename(const std::string &filepath);
-	std::string		extractFileExtension(const std::string &filepath);
 
 	// All preloaded textures
 	std::map<std::string, ci::gl::Texture2dRef>	mTexturesMap;
-	std::set<std::string> mValidExtensions;
-	ci::gl::Texture2d::Format mDefaultFormat;
+
+	static ci::gl::Texture2d::Format sDefaultFormat;
+	static bool sDefaultFormatInitialized;
 };
 
 }


### PR DESCRIPTION
ImageManager now supports
- Recursive loading of images from a dir with child dirs (addresses #19 cc @mattfelsen)
- Passing in custom texture formats on load
- By default, images are now _not_ loaded top-down anymore (latest bluecadet::views::ImageView also removes the upside-down-by-default setting)
- Filtering images by extensions on load
- Loading individual images
- Passing in custom keys for images
- Loading images from any absolute path (not just within assets)

In order to load images, when you previously used to call:

```c++
ImageManager::getInstance()->loadAllImagesInDirectory("images");
```

you should now call:

```c++
ImageManager::getInstance()->loadAllFromDir(getAssetPath("images"));
```

Adds new `FileUtils` class to recursively iterate over files in directories.
